### PR TITLE
Add coverage and publish workflows

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -6,5 +6,10 @@
   ],
   "reporter": [
     "text"
-  ]
+  ],
+  "check-coverage": true,
+  "lines": 95,
+  "functions": 95,
+  "branches": 95,
+  "statements": 95
 }

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,15 @@
+name: Coverage
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run test-coverage

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish package on manual trigger
- add coverage workflow for pull requests
- enforce minimum 95% coverage with c8

## Testing
- `npm test`
- `npm run test-coverage`
